### PR TITLE
Added ability to specify the label text

### DIFF
--- a/lib/localized_fields/form_builder.rb
+++ b/lib/localized_fields/form_builder.rb
@@ -4,14 +4,15 @@ module LocalizedFields
       @options[:language] if @options[:language]
     end
 
-    def label(attribute, options = {})
+    def label(attribute, *args)
+      options = args.extract_options!
+      text = args[0]
       if @options.has_key?(:language)
         language = @options[:language]
-
-        super(attribute, options.merge(for: "#{object_name}_#{attribute}_translations_#{language}")).html_safe
+        super(attribute, text, options.merge(for: "#{object_name}_#{attribute}_translations_#{language}")).html_safe
       else
-        field_name = @object_name.match(/.*\[(.*)_translations\]/)[1].capitalize
-        super(attribute, field_name, options).html_safe
+        text ||= @object_name.match(/.*\[(.*)_translations\]/)[1].capitalize
+        super(attribute, text, options).html_safe
       end
     end
 

--- a/spec/localized_fields_spec.rb
+++ b/spec/localized_fields_spec.rb
@@ -76,6 +76,26 @@ describe 'LocalizedFields' do
       output.should eq(expected)
     end
 
+    it 'should return a label tag with custom text' do
+      output = @builder.localized_fields(:title) do |localized_field|
+        localized_field.label :en, "The title in english"
+      end
+
+      expected = '<label for="post_title_translations_en">The title in english</label>'
+
+      output.should eq(expected)
+    end
+
+    it 'should return a label tag with custom text and options' do
+      output = @builder.localized_fields(:title) do |localized_field|
+        localized_field.label :en, "The title in english", class: "field"
+      end
+
+      expected = '<label class="field" for="post_title_translations_en">The title in english</label>'
+
+      output.should eq(expected)
+    end
+
     it 'should return a label tag for all languages' do
       output = @builder.localized_fields do |localized_field|
         localized_field.label :title


### PR DESCRIPTION
Allows further customization of forms while improving API compatibility with Rails default form builder `label` helper.
