### PR TITLE
Select locales via configuration.

### DIFF
--- a/lib/localized_fields.rb
+++ b/lib/localized_fields.rb
@@ -6,6 +6,34 @@ module LocalizedFields
 
   autoload :FormBuilder
   autoload :Helpers
+
+
+  class << self
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configuration=(config)
+      @configuration = config
+    end
+
+    def configure
+      yield(configuration)
+    end
+
+  end
+
+  class Configuration
+    attr_accessor :used_locales
+
+    def initialize
+      self.used_locales = I18n.available_locales
+    end
+  end
+
+
+
 end
 
 ActionView::Helpers::FormBuilder.send :include, LocalizedFields::Helpers::FormHelper

--- a/lib/localized_fields/helpers/form_helper.rb
+++ b/lib/localized_fields/helpers/form_helper.rb
@@ -11,7 +11,7 @@ module LocalizedFields
         else
           output = ''
 
-          I18n.available_locales.each do |language|
+          LocalizedFields.configuration.used_locales.each do |language|
             output << @template.fields_for(object_name, @object, options.merge(builder: LocalizedFields::FormBuilder, language: language), &block)
           end
 


### PR DESCRIPTION
  - Introduces configuration on module for use with initializer.
  - Adds 'used_locales' config option to limit locales without
    relying on I18n.available_locales.

In our application, we don't force any locales through `I18n.available_locales` but then do some translation trickery throughout the rest of our application. Unfortunately, this means localized_fields spits out way more locales than we actually want to focus on.

This pull request adds some configuration to choose which locales to output for based on a configuration setting. Unfortunately, it comes without documentation or specs. Sorry...