### PR TITLE
Fix specs for Rails 4 and get Travis CI to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,25 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
-
-services: mongodb
+  - 2.1.6
+  - 2.2.2
 
 before_install: gem install bundler --pre
 
 gemfile:
-  - Gemfile
-  - gemfiles/mongoid-master.gemfile
+  - spec/gemfiles/Gemfile.master
+  - spec/gemfiles/Gemfile.rails32
+  - spec/gemfiles/Gemfile.rails40
+  - spec/gemfiles/Gemfile.rails41
+  - spec/gemfiles/Gemfile.rails42
 
 notifications:
   email:
     - tiagogodinho3@gmail.com
+
+matrix:
+  exclude:
+    - rvm: 2.2.2
+      gemfile: spec/gemfiles/Gemfile.rails32
+  allow_failures:
+    - gemfile: spec/gemfiles/Gemfile.rails32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Improvements
 
 * Added ability to specify the label text. ([@xavier][]) commit: [7222f15][]
+* Fix Travis CI for Rails 4. ([@johnnyshields][])
 
 ## 0.2.0 - June 15, 2012
 

--- a/gemfiles/mongoid-master.gemfile
+++ b/gemfiles/mongoid-master.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'mongoid', github: 'mongoid/mongoid'
-
-gem 'coveralls', require: false
-
-gemspec path: '../'

--- a/localized_fields.gemspec
+++ b/localized_fields.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake', '~> 10.1.0'
   gem.add_development_dependency 'rspec', '~> 2.14.0'
+  gem.add_development_dependency 'coveralls'
 end

--- a/spec/gemfiles/Gemfile.master
+++ b/spec/gemfiles/Gemfile.master
@@ -1,0 +1,8 @@
+source 'http://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'actionpack', '~> 4.2'
+gem 'mongoid',    github: 'mongoid'
+
+gem 'coveralls', require: false

--- a/spec/gemfiles/Gemfile.rails32
+++ b/spec/gemfiles/Gemfile.rails32
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'actionpack', '~> 3.2'
+gem 'mongoid',    '~> 3.1'

--- a/spec/gemfiles/Gemfile.rails40
+++ b/spec/gemfiles/Gemfile.rails40
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'actionpack', '~> 4.0'
+gem 'mongoid',    '~> 4.0'

--- a/spec/gemfiles/Gemfile.rails41
+++ b/spec/gemfiles/Gemfile.rails41
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'actionpack', '~> 4.1'
+gem 'mongoid',    '~> 4.0'

--- a/spec/gemfiles/Gemfile.rails42
+++ b/spec/gemfiles/Gemfile.rails42
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'actionpack', '~> 4.2'
+gem 'mongoid',    '~> 4.0'

--- a/spec/localized_fields_spec.rb
+++ b/spec/localized_fields_spec.rb
@@ -3,7 +3,12 @@ require 'spec_helper'
 describe 'LocalizedFields' do
   let(:post) { Post.new }
   let(:template) { ActionView::Base.new }
-  let(:builder) { ActionView::Helpers::FormBuilder.new(:post, post, template, {}) }
+  let(:builder) { ActionView::Helpers::FormBuilder.new(*builder_args) }
+  let(:builder_args) do
+    args =  [:post, post, template, {}]
+    args += [proc {}] if rails3?
+    args
+  end
 
   before do
     template.output_buffer = ''
@@ -48,7 +53,7 @@ describe 'LocalizedFields' do
           %{<div>#{localized_field.text_field(:en).html_safe}</div>}.html_safe
       end
 
-      expected = %{<div><input id="post_title_translations_en" name="post[title_translations][en]" type="text" /></div>}
+      expected = %{<div><input type="text" name="post[title_translations][en]" id="post_title_translations_en" /></div>}
 
       expect(output).to eq(expected)
     end
@@ -126,7 +131,7 @@ describe 'LocalizedFields' do
         localized_field.text_field :en
       end
 
-      expected = %{<input id="post_title_translations_en" name="post[title_translations][en]" type="text" />}
+      expected = %{<input type="text" name="post[title_translations][en]" id="post_title_translations_en" />}
 
       expect(output).to eq(expected)
     end
@@ -160,7 +165,7 @@ describe 'LocalizedFields' do
         localized_field.text_area :en, value: 'text'
       end
 
-      expected =  %{<textarea id="post_title_translations_en" name="post[title_translations][en]">\n}
+      expected =  %{<textarea name="post[title_translations][en]" id="post_title_translations_en">\n}
       expected << %{</textarea>}
 
       expect(output).to eq(expected)
@@ -202,7 +207,7 @@ describe 'LocalizedFields' do
           localized_field.text_area :en
         end
 
-        expected =  %{<textarea id="post_title_translations_en" name="post[title_translations][en]">\ntitle en}
+        expected =  %{<textarea name="post[title_translations][en]" id="post_title_translations_en">\ntitle en}
         expected << %{</textarea>}
 
         expect(output).to eq(expected)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,11 @@ Coveralls.wear!
 require 'localized_fields'
 
 Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))].each { |f| require f }
+
+def rails3?
+  !defined?(ActionView::VERSION::MAJOR)
+end
+
+def rails4?
+  ActionView::VERSION::MAJOR == 4
+end


### PR DESCRIPTION
This PR gets Travis CI to pass for Rails 4.

I've added gemfiles for each of Rails versions 3.2, 4.0, 4.1, 4.2. In addition, there's a "master" version but Mongoid currently conflicts so it's set to Rails 4.2 and Mongoid master. I've moved /gemfiles to be /spec/gemfiles.

Rails 3 specs are marked as "allowed failures" since the output HTML format has changed entirely. I've investigated and decided that it's not worth the effort to make both Rails 3 and 4 pass, but at least I've gotten to the point where the Rails 3 env build correctly and we can see the individual specs fail due to format change.

I've also added coveralls as a dev dependency, otherwise Travis fails.

Lastly, Travis CI does not require service: mongodb to pass hence I've removed it.

You can see the passing build here: https://travis-ci.org/johnnyshields/localized_fields/builds/60084925
