### PR TITLE
Value pass-through + fix using locales not present in translations hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,25 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
-
-services: mongodb
+  - 2.1.6
+  - 2.2.2
 
 before_install: gem install bundler --pre
 
 gemfile:
-  - Gemfile
-  - gemfiles/mongoid-master.gemfile
+  - spec/gemfiles/Gemfile.master
+  - spec/gemfiles/Gemfile.rails32
+  - spec/gemfiles/Gemfile.rails40
+  - spec/gemfiles/Gemfile.rails41
+  - spec/gemfiles/Gemfile.rails42
 
 notifications:
   email:
     - tiagogodinho3@gmail.com
+
+matrix:
+  exclude:
+    - rvm: 2.2.2
+      gemfile: spec/gemfiles/Gemfile.rails32
+  allow_failures:
+    - gemfile: spec/gemfiles/Gemfile.rails32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Improvements
 
 * Added ability to specify the label text. ([@xavier][]) commit: [7222f15][]
+* Fix Travis CI for Rails 4. ([@johnnyshields][])
 
 ## 0.2.0 - June 15, 2012
 

--- a/gemfiles/mongoid-master.gemfile
+++ b/gemfiles/mongoid-master.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'mongoid', github: 'mongoid/mongoid'
-
-gem 'coveralls', require: false
-
-gemspec path: '../'

--- a/lib/localized_fields/form_builder.rb
+++ b/lib/localized_fields/form_builder.rb
@@ -38,12 +38,12 @@ module LocalizedFields
 
         value = translations.has_key?(language.to_s) ? translations[language.to_s] : nil
 
-        options = options.merge(value: value, id: "#{object_name}_#{attribute}_translations_#{language}", name: "#{object_name}[#{attribute}_translations][#{language}]")
+        options = options.merge(id: "#{object_name}_#{attribute}_translations_#{language}", name: "#{object_name}[#{attribute}_translations][#{language}]")
       else
         value = @object ? @object[attribute.to_s] : nil
-
-        options = options.merge(value: value)
       end
+
+      options[:value] ||= value || ''
 
       return attribute, options
     end

--- a/localized_fields.gemspec
+++ b/localized_fields.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake', '~> 10.1.0'
   gem.add_development_dependency 'rspec', '~> 2.14.0'
+  gem.add_development_dependency 'coveralls'
 end

--- a/spec/gemfiles/Gemfile.master
+++ b/spec/gemfiles/Gemfile.master
@@ -1,0 +1,8 @@
+source 'http://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'actionpack', '~> 4.2'
+gem 'mongoid',    github: 'mongoid'
+
+gem 'coveralls', require: false

--- a/spec/gemfiles/Gemfile.rails32
+++ b/spec/gemfiles/Gemfile.rails32
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'actionpack', '~> 3.2'
+gem 'mongoid',    '~> 3.1'

--- a/spec/gemfiles/Gemfile.rails40
+++ b/spec/gemfiles/Gemfile.rails40
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'actionpack', '~> 4.0'
+gem 'mongoid',    '~> 4.0'

--- a/spec/gemfiles/Gemfile.rails41
+++ b/spec/gemfiles/Gemfile.rails41
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'actionpack', '~> 4.1'
+gem 'mongoid',    '~> 4.0'

--- a/spec/gemfiles/Gemfile.rails42
+++ b/spec/gemfiles/Gemfile.rails42
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'actionpack', '~> 4.2'
+gem 'mongoid',    '~> 4.0'

--- a/spec/localized_fields_spec.rb
+++ b/spec/localized_fields_spec.rb
@@ -27,11 +27,11 @@ describe 'LocalizedFields' do
 
       expected =  %{<dl class="field">}
       expected <<  %{<dt><label for="post_title_translations_en">Title</label></dt>}
-      expected <<  %{<dd><input id="post_title_translations_en" name="post[title_translations][en]" type="text" /></dd>}
+      expected <<  %{<dd><input id="post_title_translations_en" name="post[title_translations][en]" value="" type="text" /></dd>}
       expected << %{</dl>}
       expected << %{<dl class="field">}
       expected <<  %{<dt><label for="post_title_translations_pt">Title</label></dt>}
-      expected <<  %{<dd><input id="post_title_translations_pt" name="post[title_translations][pt]" type="text" /></dd>}
+      expected <<  %{<dd><input id="post_title_translations_pt" name="post[title_translations][pt]" value="" type="text" /></dd>}
       expected << %{</dl>}
 
       expect(output).to eq(expected)
@@ -42,8 +42,8 @@ describe 'LocalizedFields' do
           %{<div>#{localized_field.text_field(:title).html_safe}</div>}.html_safe
       end
 
-      expected =  %{<div><input id="post_title_translations_en" name="post[title_translations][en]" type="text" /></div>}
-      expected << %{<div><input id="post_title_translations_pt" name="post[title_translations][pt]" type="text" /></div>}
+      expected =  %{<div><input id="post_title_translations_en" name="post[title_translations][en]" value="" type="text" /></div>}
+      expected << %{<div><input id="post_title_translations_pt" name="post[title_translations][pt]" value="" type="text" /></div>}
 
       expect(output).to eq(expected)
     end
@@ -53,7 +53,7 @@ describe 'LocalizedFields' do
           %{<div>#{localized_field.text_field(:en).html_safe}</div>}.html_safe
       end
 
-      expected = %{<div><input type="text" name="post[title_translations][en]" id="post_title_translations_en" /></div>}
+      expected = %{<div><input value="" type="text" name="post[title_translations][en]" id="post_title_translations_en" /></div>}
 
       expect(output).to eq(expected)
     end
@@ -131,7 +131,7 @@ describe 'LocalizedFields' do
         localized_field.text_field :en
       end
 
-      expected = %{<input type="text" name="post[title_translations][en]" id="post_title_translations_en" />}
+      expected = %{<input value="" type="text" name="post[title_translations][en]" id="post_title_translations_en" />}
 
       expect(output).to eq(expected)
     end
@@ -141,8 +141,8 @@ describe 'LocalizedFields' do
         localized_field.text_field :title
       end
 
-      expected =  %{<input id="post_title_translations_en" name="post[title_translations][en]" type="text" />}
-      expected << %{<input id="post_title_translations_pt" name="post[title_translations][pt]" type="text" />}
+      expected =  %{<input id="post_title_translations_en" name="post[title_translations][en]" value="" type="text" />}
+      expected << %{<input id="post_title_translations_pt" name="post[title_translations][pt]" value="" type="text" />}
 
       expect(output).to eq(expected)
     end
@@ -152,21 +152,58 @@ describe 'LocalizedFields' do
         localized_field.text_field :title, class: 'field'
       end
 
-      expected =  %{<input class="field" id="post_title_translations_en" name="post[title_translations][en]" type="text" />}
-      expected << %{<input class="field" id="post_title_translations_pt" name="post[title_translations][pt]" type="text" />}
+      expected =  %{<input class="field" id="post_title_translations_en" name="post[title_translations][en]" value="" type="text" />}
+      expected << %{<input class="field" id="post_title_translations_pt" name="post[title_translations][pt]" value="" type="text" />}
 
       expect(output).to eq(expected)
+    end
+
+    context 'post with values' do
+      before do
+        post.stub(:title_translations).and_return({ 'en' => 'title en', 'pt' => 'title pt' })
+      end
+
+      it 'returns a text_area tag for en' do
+        output = builder.localized_fields(:title) do |localized_field|
+          localized_field.text_field :en
+        end
+
+        expected =  %{<input value="title en" type="text" name="post[title_translations][en]" id="post_title_translations_en" />}
+
+        expect(output).to eq(expected)
+      end
+
+      it 'returns a text_area tag for ja' do
+        output = builder.localized_fields(:title) do |localized_field|
+          localized_field.text_field :ja
+        end
+
+        expected =  %{<input value="" type="text" name="post[title_translations][ja]" id="post_title_translations_ja" />}
+
+        expect(output).to eq(expected)
+      end
+
+      it 'returns a text_area tag for all languages' do
+        output = builder.localized_fields do |localized_field|
+          localized_field.text_field :title
+        end
+
+        expected =  %{<input id="post_title_translations_en" name="post[title_translations][en]" value="title en" type="text" />}
+        expected << %{<input id="post_title_translations_pt" name="post[title_translations][pt]" value="title pt" type="text" />}
+
+        expect(output).to eq(expected)
+      end
     end
   end
 
   describe 'text_area' do
     it 'returns a text_area tag for en' do
       output = builder.localized_fields(:title) do |localized_field|
-        localized_field.text_area :en, value: 'text'
+        localized_field.text_area :en, value: 'My Value'
       end
 
       expected =  %{<textarea name="post[title_translations][en]" id="post_title_translations_en">\n}
-      expected << %{</textarea>}
+      expected << %{My Value</textarea>}
 
       expect(output).to eq(expected)
     end
@@ -208,6 +245,17 @@ describe 'LocalizedFields' do
         end
 
         expected =  %{<textarea name="post[title_translations][en]" id="post_title_translations_en">\ntitle en}
+        expected << %{</textarea>}
+
+        expect(output).to eq(expected)
+      end
+
+      it 'returns a text_area tag for ja' do
+        output = builder.localized_fields(:title) do |localized_field|
+          localized_field.text_area :ja
+        end
+
+        expected =  %{<textarea name="post[title_translations][ja]" id="post_title_translations_ja">\n}
         expected << %{</textarea>}
 
         expect(output).to eq(expected)

--- a/spec/localized_fields_spec.rb
+++ b/spec/localized_fields_spec.rb
@@ -3,7 +3,12 @@ require 'spec_helper'
 describe 'LocalizedFields' do
   let(:post) { Post.new }
   let(:template) { ActionView::Base.new }
-  let(:builder) { ActionView::Helpers::FormBuilder.new(:post, post, template, {}) }
+  let(:builder) { ActionView::Helpers::FormBuilder.new(*builder_args) }
+  let(:builder_args) do
+    args =  [:post, post, template, {}]
+    args += [proc {}] if rails3?
+    args
+  end
 
   before do
     template.output_buffer = ''
@@ -48,7 +53,7 @@ describe 'LocalizedFields' do
           %{<div>#{localized_field.text_field(:en).html_safe}</div>}.html_safe
       end
 
-      expected = %{<div><input id="post_title_translations_en" name="post[title_translations][en]" type="text" /></div>}
+      expected = %{<div><input type="text" name="post[title_translations][en]" id="post_title_translations_en" /></div>}
 
       expect(output).to eq(expected)
     end
@@ -126,7 +131,7 @@ describe 'LocalizedFields' do
         localized_field.text_field :en
       end
 
-      expected = %{<input id="post_title_translations_en" name="post[title_translations][en]" type="text" />}
+      expected = %{<input type="text" name="post[title_translations][en]" id="post_title_translations_en" />}
 
       expect(output).to eq(expected)
     end
@@ -160,7 +165,7 @@ describe 'LocalizedFields' do
         localized_field.text_area :en, value: 'text'
       end
 
-      expected =  %{<textarea id="post_title_translations_en" name="post[title_translations][en]">\n}
+      expected =  %{<textarea name="post[title_translations][en]" id="post_title_translations_en">\n}
       expected << %{</textarea>}
 
       expect(output).to eq(expected)
@@ -202,7 +207,7 @@ describe 'LocalizedFields' do
           localized_field.text_area :en
         end
 
-        expected =  %{<textarea id="post_title_translations_en" name="post[title_translations][en]">\ntitle en}
+        expected =  %{<textarea name="post[title_translations][en]" id="post_title_translations_en">\ntitle en}
         expected << %{</textarea>}
 
         expect(output).to eq(expected)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,11 @@ Coveralls.wear!
 require 'localized_fields'
 
 Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))].each { |f| require f }
+
+def rails3?
+  !defined?(ActionView::VERSION::MAJOR)
+end
+
+def rails4?
+  ActionView::VERSION::MAJOR == 4
+end


### PR DESCRIPTION
**This PR includes / is dependent on #12 which gets Travis CI to pass**

This PR resolves two issues:

1) User-set `:value` key should pass-through to the underlying fields if there is no value present in translations hash. In other words, `:value` should become a "default value".

```ruby
  localized_field.text_area :en, value: 'My Value'

   #=> current:
   #   <textarea name="post[title_translations][en]" id="post_title_translations_en">
   #   </textarea>

   #=> new:
   #   <textarea name="post[title_translations][en]" id="post_title_translations_en">
   #   My Value
   #   </textarea>
```

2) On Rails 3 (possibly other versions) there's an issue when you make a localized_field for a locale which is NOT present in the model's translations hash.

I believe the root cause is that Rails can't handle a `Hash` type field value for `text_area` / `text_field` as it expects a `String`. To work around this issue, I've coerced the field value to an empty string instead of nil.

For example:

```ruby
   post.title_translations = {"ja" => "My value"}

   f.localized_fields(:title) do |localized_field|
     localized_field.text_field :en
   end
```

will throw error:

```
2015-04-26 19:13:52.131 FATAL 
NoMethodError - undefined method `en' for {"ja"=>"My value"}:Hash:
  actionpack (3.2.20) lib/action_view/helpers/form_helper.rb:1159:in `value_before_type_cast'
  actionpack (3.2.20) lib/action_view/helpers/form_helper.rb:1147:in `value_before_type_cast'
  actionpack (3.2.20) lib/action_view/helpers/form_helper.rb:1041:in `block in to_input_field_tag'
  actionpack (3.2.20) lib/action_view/helpers/form_helper.rb:1041:in `to_input_field_tag'
  actionpack (3.2.20) lib/action_view/helpers/form_helper.rb:690:in `text_field'
  actionpack (3.2.20) lib/action_view/helpers/form_helper.rb:1283:in `text_field'
  (eval):4:in `text_field_with_client_side_validations'
   () Ruby21/lib/ruby/gems/2.1.0/bundler/gems/localized_fields-8a8343b9da47/lib/localized_fields/form_builder.rb:22:in `text_field'
```