### PR TITLE
Update gemspec to support mongoid 5.

### DIFF
--- a/localized_fields.gemspec
+++ b/localized_fields.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = LocalizedFields::VERSION
 
-  gem.add_dependency 'mongoid',    '>= 2.4',   '< 5'
-  gem.add_dependency 'actionpack', '>= 3.0.0', '< 5'
+  gem.add_dependency 'mongoid',    '>= 2.4'
+  gem.add_dependency 'actionpack', '>= 3.0.0'
 
   gem.add_development_dependency 'rake', '~> 10.1.0'
   gem.add_development_dependency 'rspec', '~> 2.14.0'


### PR DESCRIPTION
Hello,

This PR contains a single commit relaxing the gemspec rules, so it is possible to bundle this gem in projects with mongoid 5 without conflicts.

All tests pass, so I think it's safe to merge:

```
➜  localized_fields git:(master) ✗ rspec
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
.....................

Finished in 0.11553 seconds
21 examples, 0 failures
[Coveralls] Outside the CI environment, not sending data.
```

Best regards.
